### PR TITLE
Removed unnecessary dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   "license": "ISC",
   "dependencies": {
     "chalk": "^1.1.3",
-    "fs": "0.0.1-security",
     "fs-promise": "^0.5.0",
     "glob": "^7.1.0",
     "is-directory": "^0.3.1",


### PR DESCRIPTION
Heya, just a quickie-PR. This package is a spam/placeholder package in npm which doesn't serve any purpose other than being an extra dependency. The fs module is built-in so there is no need to explicitly add it to the dependency list. There's more info on this here: https://www.npmjs.com/package/fs and here: http://status.npmjs.org/incidents/dw8cr1lwxkcr. 😃